### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,23 +5,23 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-eOID_d		(KEYWORD1)
-eSessionCtxId_d (KEYWORD1)
+eOID_d	KEYWORD1
+eSessionCtxId_d	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin		KEYWORD2
+begin	KEYWORD2
 checkChip	KEYWORD2
-reset		KEYWORD2
+reset	KEYWORD2
 getCertificate	KEYWORD2
-getPublicKey KEYWORD2
+getPublicKey	KEYWORD2
 getUniqueID	KEYWORD2
 getRandom	KEYWORD2
 getCurrentLimit	KEYWORD2
 setCurrentLimit	KEYWORD2
 getLastErrorCodes	KEYWORD2
-sha256		KEYWORD2
+sha256	KEYWORD2
 calculateSignature	KEYWORD2
 formatSignature	KEYWORD2
 verifySignature	KEYWORD2
@@ -38,7 +38,7 @@ trustX	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-eLCS_G			LITERAL1
+eLCS_G	LITERAL1
 eSECURITY_STATUS_G	LITERAL1
 eCOPROCESSOR_UID	LITERAL1
 eSLEEP_MODE_ACTIVATION_DELAY	LITERAL1
@@ -52,6 +52,6 @@ eFIRST_DEVICE_PRIKEY_1	LITERAL1
 eFIRST_DEVICE_PRIKEY_2	LITERAL1
 eFIRST_DEVICE_PRIKEY_3	LITERAL1
 eFIRST_DEVICE_PRIKEY_4	LITERAL1
-eLCS_A			LITERAL1
+eLCS_A	LITERAL1
 eSECURITY_STATUS_A	LITERAL1
-eERROR_CODES		LITERAL1
+eERROR_CODES	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords